### PR TITLE
many: start session ID at 1, dont keep track

### DIFF
--- a/lib/wampproto/id_generator.rb
+++ b/lib/wampproto/id_generator.rb
@@ -5,15 +5,9 @@ module Wampproto
   class IdGenerator
     MAX_ID = 1 << 53
 
-    @ids = {}
     class << self
       def generate_session_id
-        id = rand(100_000..MAX_ID)
-        if @ids.include?(id)
-          generate_session_id
-        else
-          @ids[id] = id
-        end
+        rand(1..MAX_ID)
       end
     end
 
@@ -22,11 +16,8 @@ module Wampproto
     end
 
     def next
-      if @id == MAX_ID
-        @id = 0
-      else
-        @id += 1
-      end
+      @id = 0 if @id == MAX_ID
+      @id += 1
     end
   end
 end


### PR DESCRIPTION
* start session scope IDs at 1
* don't keep track of session IDs
* Start session IDs from 1 instead of 100_000

closes https://github.com/xconnio/wampproto-ruby/issues/33